### PR TITLE
fix leaderboard query

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,16 +233,10 @@ app.get('/api/leaderboard-stats/:format', async (req, response) => {
     (SELECT *, 
             ((cbt*2) + (eff*0.5) + (eva*0.5) + (imp*2) + spt + srv) / 7.0 AS avg_score
         FROM player_card_info
-        WHERE (seasonid = ${seasonid} AND format = '${format}')
+        WHERE (seasonid = ${seasonid} AND format = ${format})
         ORDER BY avg_score DESC) as T1
-  INNER JOIN
-    (SELECT tf2gamers.steamid, teams.teamname, teams.teamid, tf2gamers.rglname
-        FROM playerteams
-        INNER JOIN tf2gamers ON tf2gamers.steamid = playerteams.steamid
-        INNER JOIN teams ON playerteams.teamid = teams.teamid
-        WHERE date_left=-1
-        AND playerteams.seasonid=${seasonid}) as playerinfo
-  ON T1.id64 = playerinfo.steamid`;
+  inner JOIN
+    tf2gamers on tf2gamers.steamid=T1.id64 `;
 
     const result = await pool.query(queryText);
 


### PR DESCRIPTION
old one doesnt work after the season ends